### PR TITLE
networkImageWithSpinner widget for progress indicator support.

### DIFF
--- a/lib/ui/screen/sight_card.dart
+++ b/lib/ui/screen/sight_card.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:places/domain/sight.dart';
 import 'package:places/ui/res/app_colors.dart';
 import 'package:places/ui/res/app_text_styles.dart';
+import 'package:places/ui/widgets/network_image_with_spinner.dart';
 
 class SightCard extends StatelessWidget {
   final Sight sight;
@@ -18,27 +19,30 @@ class SightCard extends StatelessWidget {
           crossAxisAlignment: CrossAxisAlignment.stretch,
           children: [
             Expanded(
-              child: Container(
-                decoration: BoxDecoration(
-                  image: DecorationImage(
-                    image: NetworkImage(sight.url),
-                    fit: BoxFit.cover,
+              child: Stack(
+                children: [
+                  Container(
+                    width: double.infinity,
+                    child: NetworkImageWithSpinner(url: sight.url),
                   ),
-                ),
-                child: Padding(
-                  padding: const EdgeInsets.all(16.0),
-                  child: Row(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                    children: [
-                      Text(sight.type, style: AppTextStyles.sightCardType),
-                      Icon(
-                        Icons.favorite_outline,
-                        color: AppColors.white,
-                      ),
-                    ],
-                  ),
-                ),
+                  Padding(
+                    padding: const EdgeInsets.all(16.0),
+                    child: Row(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                      children: [
+                        Text(
+                          sight.type,
+                          style: AppTextStyles.sightCardType,
+                        ),
+                        Icon(
+                          Icons.favorite_outline,
+                          color: AppColors.white,
+                        ),
+                      ],
+                    ),
+                  )
+                ],
               ),
             ),
             Expanded(

--- a/lib/ui/widgets/network_image_with_spinner.dart
+++ b/lib/ui/widgets/network_image_with_spinner.dart
@@ -1,0 +1,36 @@
+import 'package:flutter/material.dart';
+
+class NetworkImageWithSpinner extends StatelessWidget {
+  final String url;
+  final BoxFit fit;
+
+  const NetworkImageWithSpinner({
+    Key key,
+    this.url,
+    this.fit = BoxFit.cover,
+  }) : super(key: key);
+  @override
+  Widget build(BuildContext context) {
+    return Image.network(
+      url,
+      fit: fit,
+      loadingBuilder: (context, child, loadingProgress) {
+        if (loadingProgress == null) {
+          // загрузка завершена, показываем картинку
+          return child;
+        } else {
+          // в документации expectedTotalBytes может быть null поэтому в этом кейсе показываем простую крутилку
+          if (loadingProgress.expectedTotalBytes == null || loadingProgress.expectedTotalBytes == 0) {
+            return CircularProgressIndicator();
+          }
+
+          // Вычисляем прогресс для спиннера
+          final progress = loadingProgress.cumulativeBytesLoaded / loadingProgress.expectedTotalBytes;
+          return Center(
+            child: CircularProgressIndicator(value: progress),
+          );
+        }
+      },
+    );
+  }
+}


### PR DESCRIPTION
### лоадер

для реализации лоадера изменил верстку SightCard с conteiner + decoration image на stack + image.

В качестве лоадера сделал виджет NetworkImageWithSpinner, который показывает по центру спиннер с прогрессом во время загрузки

![Simulator Screen Shot - iPhone 8 - 2020-12-08 at 14 44 12](https://user-images.githubusercontent.com/426492/101481177-cb497080-3965-11eb-9a26-10ff0a62b2a8.png)


![Simulator Screen Shot - iPhone 8 - 2020-12-08 at 14 56 33](https://user-images.githubusercontent.com/426492/101481181-ce446100-3965-11eb-911b-a1aec0e4cd92.png)
