### PR TITLE
Sight detail bottom sheet fix

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,10 @@
+### 8.2.1 Sight detail bottom sheet fix 21.01.2021
+- переделал bottomSheet на DraggableScrollableSheet.
+Спасибо, то, что нужно. Теперь при свайпе вниз botoomSheet закрывается и возможность скролла сохранилась.
+Добавил даже SliverPersistentHeader, реализованный ранее на SightDetailsScreen, чтобы карусель красиво схлопывалась и кнопочка закрытия исчезала от скролла.
+
+- скруглил углы наверху. В теме прозрачный фон для bottomSheetTheme, а контент обернул в ClipRRect.
+
 ### 8.2 Sight detail bottom sheet
 - Заменил страницу SightDetailsScreen на bottomSheet
 Столкнулся с такой трудностью - не удавалось добиться одновременной возможности скролла контента на bottomSheet и свайпа вниз для закрытия.

--- a/lib/ui/res/themes.dart
+++ b/lib/ui/res/themes.dart
@@ -70,6 +70,9 @@ final lightTheme = ThemeData.light().copyWith(
     hintStyle: AppTextStyles.addSightCategory
         .copyWith(color: AppColors.ltDisabledColor),
   ),
+  bottomSheetTheme: const BottomSheetThemeData(
+    backgroundColor: Colors.transparent,
+  ),
 );
 
 final darkTheme = ThemeData.dark().copyWith(
@@ -137,5 +140,8 @@ final darkTheme = ThemeData.dark().copyWith(
     ),
     hintStyle: AppTextStyles.addSightCategory
         .copyWith(color: AppColors.dkDisabledColor),
+  ),
+  bottomSheetTheme: const BottomSheetThemeData(
+    backgroundColor: Colors.transparent,
   ),
 );


### PR DESCRIPTION
### 8.2.1 Sight detail bottom sheet fix 21.01.2021
- переделал bottomSheet на DraggableScrollableSheet.
Спасибо, то, что нужно. Теперь при свайпе вниз botoomSheet закрывается и возможность скролла сохранилась.
Добавил даже SliverPersistentHeader, реализованный ранее на SightDetailsScreen, чтобы карусель красиво схлопывалась и кнопочка закрытия исчезала от скролла.

- скруглил углы наверху. В теме прозрачный фон для bottomSheetTheme, а контент обернул в ClipRRect.


https://user-images.githubusercontent.com/426492/105388142-5a190080-5c27-11eb-9bf6-f556faf5d090.mov

