### PR TITLE
favorite btn

### DIFF
--- a/lib/model/favorites/changes.dart
+++ b/lib/model/favorites/changes.dart
@@ -1,5 +1,15 @@
 import 'package:mwwm/mwwm.dart';
 import 'package:places/domain/sight.dart';
+import 'package:places/model/favorites/performers.dart';
+
+/// Переключает состояние Favorite
+/// перформер Возвращает ToggleFavoriteResult,
+/// в котором есть sight.id и новое состояние Favorite
+class ToggleFavorite extends FutureChange<ToggleFavoriteResult> {
+  final Sight sight;
+
+  ToggleFavorite(this.sight);
+}
 
 /// Добавить место в избранное
 class AddToFavorite extends FutureChange<void> {

--- a/lib/model/favorites/performers.dart
+++ b/lib/model/favorites/performers.dart
@@ -8,6 +8,39 @@ import 'package:places/model/repository/favorites_repository.dart';
 import 'package:places/model/repository/location_repository.dart';
 import 'package:places/model/repository/sight_repository.dart';
 
+/// результат работы ToggleFavoritePerformer
+class ToggleFavoriteResult {
+  final int sightId;
+  final bool isFavorite;
+
+  ToggleFavoriteResult({this.sightId, this.isFavorite});
+}
+
+/// Переключение состояния избранного
+class ToggleFavoritePerformer
+    extends Broadcast<ToggleFavoriteResult, ToggleFavorite> {
+  final FavoritesRepository favoritesRepository;
+
+  ToggleFavoritePerformer(this.favoritesRepository);
+
+  @override
+  Future<ToggleFavoriteResult> performInternal(ToggleFavorite change) async {
+    final bool isFav = await favoritesRepository.isFavorite(change.sight.id);
+
+    if (isFav) {
+      favoritesRepository.remove(change.sight.id);
+    } else {
+      favoritesRepository.add(change.sight.id);
+    }
+    return Future.value(
+      ToggleFavoriteResult(
+        sightId: change.sight.id,
+        isFavorite: !isFav,
+      ),
+    );
+  }
+}
+
 /// Добавление места в избранное
 class AddToFavoritePerformer extends FuturePerformer<void, AddToFavorite> {
   final FavoritesRepository favoritesRepository;

--- a/lib/ui/screen/sight_details_screen/sight_details_bottomsheet.dart
+++ b/lib/ui/screen/sight_details_screen/sight_details_bottomsheet.dart
@@ -17,16 +17,23 @@ import 'package:relation/relation.dart';
 
 /// BottomSheet подробного представления "Интересного места"
 class SightDetailsBottomSheet extends CoreMwwmWidget {
-  SightDetailsBottomSheet({@required Sight sight})
+  SightDetailsBottomSheet({@required Sight sight, Model model})
       : assert(sight != null),
         super(widgetModelBuilder: (context) {
           return SightDetailsWm(
             context.read<WidgetModelDependencies>(),
-            Model([
-              AddToFavoritePerformer(context.read<FavoritesRepository>()),
-              RemoveFromFavoritePerformer(context.read<FavoritesRepository>()),
-              GetFavoriteStatePerformer(context.read<FavoritesRepository>()),
-            ]),
+            model ??
+                Model([
+                  AddToFavoritePerformer(
+                    context.read<FavoritesRepository>(),
+                  ),
+                  RemoveFromFavoritePerformer(
+                    context.read<FavoritesRepository>(),
+                  ),
+                  GetFavoriteStatePerformer(
+                    context.read<FavoritesRepository>(),
+                  ),
+                ]),
             Navigator.of(context),
             sight: sight,
           );

--- a/lib/ui/screen/sight_details_screen/sight_details_wm.dart
+++ b/lib/ui/screen/sight_details_screen/sight_details_wm.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart' hide Action;
 import 'package:mwwm/mwwm.dart';
 import 'package:places/domain/sight.dart';
 import 'package:places/model/favorites/changes.dart';
+import 'package:places/model/favorites/performers.dart';
 import 'package:relation/relation.dart';
 
 /// wm для SightDetailsBottomSheet
@@ -31,6 +32,13 @@ class SightDetailsWm extends WidgetModel {
     super.onBind();
     subscribe(onBack.stream, (_) => _onBack());
     subscribe(onFavorite.stream, (_) => _onFavorite());
+
+    /// Слушаем change и обновляем стейт, если прилетело событие про наш sight
+    model.listen<ToggleFavoriteResult, ToggleFavorite>().listen((res) {
+      if (res.sightId == sight.id) {
+        isFavorite.accept(res.isFavorite);
+      }
+    });
   }
 
   @override
@@ -45,14 +53,7 @@ class SightDetailsWm extends WidgetModel {
     isFavorite.accept(isFav);
   }
 
-  void _onFavorite() {
-    if (isFavorite.value) {
-      model.perform(RemoveFromFavorite(sight));
-    } else {
-      model.perform(AddToFavorite(sight));
-    }
-    isFavorite.accept(!isFavorite.value);
-  }
+  void _onFavorite() => model.perform(ToggleFavorite(sight));
 
   void _onBack() => navigator.pop();
 }

--- a/lib/ui/screen/sight_list_screen/sight_list_screen.dart
+++ b/lib/ui/screen/sight_list_screen/sight_list_screen.dart
@@ -80,7 +80,12 @@ class _SightListScreenState extends WidgetState<SightListWm> {
           onTap: () => wm.showDetails(sight),
           actionsBuilder: (_) {
             return [
-              FavoriteButton(sight),
+              /// ?????????????????????????
+              /// Вот тут wm.model @protected и ругается
+              FavoriteButton(
+                sight: sight,
+                model: wm.model,
+              ),
             ];
           },
         ),

--- a/lib/ui/screen/sight_list_screen/sight_list_screen_route.dart
+++ b/lib/ui/screen/sight_list_screen/sight_list_screen_route.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:mwwm/mwwm.dart';
+import 'package:places/model/favorites/performers.dart';
+import 'package:places/model/repository/favorites_repository.dart';
 import 'package:places/model/repository/location_repository.dart';
 import 'package:places/model/repository/sight_repository.dart';
 import 'package:places/model/sights/performers.dart';
@@ -23,6 +25,8 @@ WidgetModel _wmBuilder(BuildContext context) {
         sightRepository: context.read<SightRepository>(),
         locationRepository: context.read<LocationRepository>(),
       ),
+      GetFavoriteStatePerformer(context.read<FavoritesRepository>()),
+      ToggleFavoritePerformer(context.read<FavoritesRepository>()),
     ]),
     Navigator.of(context),
   );

--- a/lib/ui/screen/sight_list_screen/sight_list_wm.dart
+++ b/lib/ui/screen/sight_list_screen/sight_list_wm.dart
@@ -106,7 +106,10 @@ class SightListWm extends WidgetModel {
         context: navigator.context,
         isScrollControlled: true,
         builder: (_) {
-          return SightDetailsBottomSheet(sight: sight);
+          return SightDetailsBottomSheet(
+            sight: sight,
+            model: model,
+          );
         });
   }
 }

--- a/lib/ui/screen/sight_list_screen/widget/favorite_button/favorite_button.dart
+++ b/lib/ui/screen/sight_list_screen/widget/favorite_button/favorite_button.dart
@@ -11,15 +11,18 @@ import 'package:relation/relation.dart';
 
 /// Кнопка избранное для карточки места.
 class FavoriteButton extends CoreMwwmWidget {
-  FavoriteButton(Sight sight)
+  FavoriteButton({@required Sight sight, Model model})
       : super(widgetModelBuilder: (context) {
           return FavoriteButtonWm(
             context.read<WidgetModelDependencies>(),
-            Model([
-              AddToFavoritePerformer(context.read<FavoritesRepository>()),
-              RemoveFromFavoritePerformer(context.read<FavoritesRepository>()),
-              GetFavoriteStatePerformer(context.read<FavoritesRepository>()),
-            ]),
+            model ??
+                Model([
+                  AddToFavoritePerformer(context.read<FavoritesRepository>()),
+                  RemoveFromFavoritePerformer(
+                      context.read<FavoritesRepository>()),
+                  GetFavoriteStatePerformer(
+                      context.read<FavoritesRepository>()),
+                ]),
             sight: sight,
           );
         });

--- a/lib/ui/screen/sight_list_screen/widget/favorite_button/favorite_button_wm.dart
+++ b/lib/ui/screen/sight_list_screen/widget/favorite_button/favorite_button_wm.dart
@@ -2,6 +2,7 @@ import 'package:flutter/foundation.dart';
 import 'package:mwwm/mwwm.dart';
 import 'package:places/domain/sight.dart';
 import 'package:places/model/favorites/changes.dart';
+import 'package:places/model/favorites/performers.dart';
 import 'package:relation/relation.dart';
 
 /// wm для кнопки избранного.
@@ -26,6 +27,14 @@ class FavoriteButtonWm extends WidgetModel {
   void onBind() {
     super.onBind();
     subscribe(onTap.stream, _onTap);
+
+    /// Слушаем ToggleFavorite и обновляем стейт,
+    /// если прилетело событие про наш sight
+    model.listen<ToggleFavoriteResult, ToggleFavorite>().listen((res) {
+      if (res.sightId == sight.id) {
+        isFavorite.accept(res.isFavorite);
+      }
+    });
   }
 
   @override
@@ -41,12 +50,5 @@ class FavoriteButtonWm extends WidgetModel {
   }
 
   // при тапе на кнопку меняем состояние избранного
-  void _onTap(_) {
-    if (isFavorite.value) {
-      model.perform(RemoveFromFavorite(sight));
-    } else {
-      model.perform(AddToFavorite(sight));
-    }
-    isFavorite.accept(!isFavorite.value);
-  }
+  void _onTap(_) => model.perform(ToggleFavorite(sight));
 }


### PR DESCRIPTION
Добрый день,

Про кнопку favorite, я вот как сделал.
Напомню, вот такая задача:  На экране списка мест у карточек есть кнопка Favorite. Она упраляется mwwm. И на bottomSheet, с подробностями места, есть другая кнопка которая меняет состояние Favorite. При возврате с bottomSheet, состояние кнопки Favorite, соответственно не меняется. Думаю как сделать чтобы весь экран не обновлять. Видел StreamPerformer, Broadcast. ...

Сделал вот такой перформер:
```ToggleFavoritePerformer extends Broadcast```

1. mwwm Список карточек  (SightListScreen)
2. на нем Карточки, с mwwm кнопкой favorite на каждой (FavoriteButton), они тригерят ToggleFavorite
3. и bottomSheet с другой mwwm кнопкой favorite (SightDetailsBottomSheet), тоже тригерит ToggleFavorite
	 
Я завел Model на верхнем уровне - SightListScreen, и передаю ее в кнопки на карточках FavoriteButton и в SightDetailsBottomSheet.

В wm от FavoriteButton и SightDetailsBottomSheet я подписался на обновления по нужному ToggleFavorite и обновляю нужные элементы в ui:

```dart
model.listen<ToggleFavoriteResult, ToggleFavorite>().listen((res) {  
  if (res.sightId == sight.id) {  
    isFavorite.accept(res.isFavorite);  
 }  
```

Так все работает верно, но есть один момент.  При передаче model в конструктор кнопки ```FavoriteButton(sight: sight, model: wm.model)``` в самом виджете, ругается на *The member 'model' can only be used within instance members of subclasses of 'package:mwwm/src/widget_model.dart*  он там ```@protected```

Правильно ли я "готовлю" это? )

А вот пришла идея... Можно было вообще создать Model с нужными Favorite-перформерами наверху дерева, передать через Provider, и брать из контекста?

Вот так:  https://github.com/kirimi/surf-flutter-course-mironov/pull/59

сорри, много текста )